### PR TITLE
Add webcam silhouette overlay, score text pop, fix webcam shutdown

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,6 +92,7 @@
     }
     #beat-counter, #fps-display { font-size: 1rem; color: #aaa; }
 
+    /* Video + overlays */
     #video-container {
       position: relative;
       display: inline-block;
@@ -103,24 +104,55 @@
       display: block;
     }
 
-    /* Fading border flash over video */
-    #border-flash {
+    /* Score text pop  (GREAT / OK / BAD) */
+    #score-text {
       position: absolute;
-      inset: 0;
-      border-radius: 8px;
-      border: 12px solid transparent;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(1);
+      font-size: 5rem;
+      font-weight: 900;
+      letter-spacing: 4px;
+      text-transform: uppercase;
       pointer-events: none;
-      transition: opacity 0.05s linear;
+      opacity: 0;
+      text-shadow: 0 0 20px currentColor, 0 0 40px currentColor;
+      transition: none;
+    }
+    #score-text.GREAT { color: #00ff88; }
+    #score-text.OK    { color: #ffdd00; }
+    #score-text.BAD   { color: #ff3333; }
+    #score-text.pop {
+      animation: score-pop 0.55s ease-out forwards;
+    }
+    @keyframes score-pop {
+      0%   { opacity: 1; transform: translate(-50%, -50%) scale(0.6); }
+      30%  { opacity: 1; transform: translate(-50%, -50%) scale(1.15); }
+      60%  { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+      100% { opacity: 0; transform: translate(-50%, -50%) scale(1.0); }
     }
 
-    /* ── Per-player score cards ── */
+    /* Silhouette overlay — bottom-right corner, small */
+    #silhouette-overlay {
+      position: absolute;
+      bottom: 12px;
+      right: 12px;
+      width: 180px;
+      border-radius: 6px;
+      /* mix-blend-mode:screen makes the black background invisible */
+      mix-blend-mode: screen;
+      opacity: 0.9;
+      pointer-events: none;
+    }
+    #silhouette-overlay.hidden { display: none; }
+
+    /* Per-player score cards */
     #player-scores {
       display: flex;
       flex-wrap: wrap;
       gap: 14px;
       margin-top: 16px;
     }
-
     .player-score {
       padding: 14px 22px;
       border-radius: 8px;
@@ -130,10 +162,10 @@
       text-align: center;
       transition: background 0.15s, color 0.15s;
     }
-    .player-score.idle    { background: #333; color: #777; }
-    .player-score.GREAT   { background: rgba(0, 200, 80, 0.85); color: #fff; }
-    .player-score.OK      { background: rgba(220, 200, 0, 0.85); color: #fff; }
-    .player-score.BAD     { background: rgba(220, 40, 40, 0.85); color: #fff; }
+    .player-score.idle  { background: #333; color: #777; }
+    .player-score.GREAT { background: rgba(0, 200, 80, 0.85);  color: #fff; }
+    .player-score.OK    { background: rgba(220, 200, 0, 0.85); color: #fff; }
+    .player-score.BAD   { background: rgba(220, 40, 40, 0.85); color: #fff; }
 
     .hidden { display: none !important; }
   </style>
@@ -180,7 +212,12 @@
 
   <div id="video-container">
     <img id="video-frame" alt="Game video" />
-    <div id="border-flash"></div>
+
+    <!-- Score text pop in the centre of the video -->
+    <div id="score-text"></div>
+
+    <!-- Glowing player silhouette in bottom-right corner -->
+    <img id="silhouette-overlay" class="hidden" alt="" />
   </div>
 
   <div id="player-scores"></div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,21 +1,23 @@
 // ── DOM refs ──────────────────────────────────────────────────────────────
-const menu        = document.getElementById('menu')!;
-const game        = document.getElementById('game')!;
-const songList    = document.getElementById('song-list')!;
-const uploadForm  = document.getElementById('upload-form')!;
-const playerScores= document.getElementById('player-scores')!;
-const videoFrame  = document.getElementById('video-frame') as HTMLImageElement;
-const borderFlash = document.getElementById('border-flash')!;
-const beatCounter = document.getElementById('beat-counter')!;
-const fpsDisplay  = document.getElementById('fps-display')!;
-const btnStart    = document.getElementById('btn-start') as HTMLButtonElement;
-const uploadStatus= document.getElementById('upload-status')!;
-const gameAudio   = document.getElementById('game-audio') as HTMLAudioElement;
+const menu             = document.getElementById('menu')!;
+const game             = document.getElementById('game')!;
+const songList         = document.getElementById('song-list')!;
+const uploadForm       = document.getElementById('upload-form')!;
+const playerScores     = document.getElementById('player-scores')!;
+const videoFrame       = document.getElementById('video-frame') as HTMLImageElement;
+const scoreText        = document.getElementById('score-text')!;
+const silhouetteOverlay= document.getElementById('silhouette-overlay') as HTMLImageElement;
+const beatCounter      = document.getElementById('beat-counter')!;
+const fpsDisplay       = document.getElementById('fps-display')!;
+const btnStart         = document.getElementById('btn-start') as HTMLButtonElement;
+const uploadStatus     = document.getElementById('upload-status')!;
+const gameAudio        = document.getElementById('game-audio') as HTMLAudioElement;
 
 // ── State ─────────────────────────────────────────────────────────────────
 let selectedSong: string | null = null;
 let ws: WebSocket | null = null;
 let lastFrameMs = 0;
+let scorePopTimeout: ReturnType<typeof setTimeout> | null = null;
 
 interface PlayerState { rating: string; updatedAt: number; }
 const playerStates = new Map<string, PlayerState>();
@@ -25,7 +27,7 @@ const EFFECT_DURATION_MS = 500;
 // ── Song list ─────────────────────────────────────────────────────────────
 async function loadSongs() {
   try {
-    const res = await fetch('/songs');
+    const res  = await fetch('/songs');
     const data = await res.json() as { songs: string[] };
     renderSongList(data.songs);
   } catch {
@@ -60,19 +62,15 @@ function selectSong(name: string) {
 async function startGame() {
   if (!selectedSong) return;
 
-  const res = await fetch(`/start/${selectedSong}`, { method: 'POST' });
+  const res  = await fetch(`/start/${selectedSong}`, { method: 'POST' });
   const data = await res.json() as { status?: string; error?: string };
   if (data.error) { alert(data.error); return; }
 
   menu.style.display = 'none';
   game.style.display = 'block';
 
-  // Play audio from server
   gameAudio.src = `/song/${selectedSong}/audio`;
-  gameAudio.play().catch(() => {
-    // Autoplay may be blocked; user can unmute manually
-    console.warn('Audio autoplay blocked');
-  });
+  gameAudio.play().catch(() => console.warn('Audio autoplay blocked'));
 
   connectWebSocket();
 }
@@ -84,13 +82,14 @@ async function stopGame() {
 }
 
 function showMenu() {
-  game.style.display = 'none';
-  menu.style.display = 'block';
+  game.style.display  = 'none';
+  menu.style.display  = 'block';
   gameAudio.pause();
   ws = null;
   playerStates.clear();
   playerScores.innerHTML = '';
   lastFrameMs = 0;
+  silhouetteOverlay.classList.add('hidden');
   loadSongs();
 }
 
@@ -100,30 +99,30 @@ function connectWebSocket() {
   ws = new WebSocket(`${proto}://${location.host}/ws`);
 
   ws.onmessage = (ev) => {
-    try {
-      handleMessage(JSON.parse(ev.data as string));
-    } catch { /* ignore parse errors */ }
+    try { handleMessage(JSON.parse(ev.data as string)); }
+    catch { /* ignore parse errors */ }
   };
 
   ws.onclose = () => showMenu();
 }
 
 interface FrameMsg {
-  type: 'frame';
-  frame: string;
-  scores: Record<string, string>;
+  type:       'frame';
+  frame:      string;
+  scores:     Record<string, string>;
   cumulative: Record<string, number>;
-  beat: number;
-  effect_ms: number | null;
+  beat:       number;
+  effect_ms:  number | null;
+  silhouette: string | null;
 }
 
 function handleMessage(msg: { type: string } & Partial<FrameMsg>) {
   if (msg.type === 'stopped') { showMenu(); return; }
-  if (msg.type !== 'frame') return;
+  if (msg.type !== 'frame')   return;
 
-  const { frame, scores = {}, cumulative = {}, beat = 0, effect_ms } = msg;
+  const { frame, scores = {}, cumulative = {}, beat = 0, effect_ms, silhouette } = msg;
 
-  // Update video frame
+  // Video frame
   if (frame) videoFrame.src = `data:image/jpeg;base64,${frame}`;
 
   // FPS
@@ -133,11 +132,48 @@ function handleMessage(msg: { type: string } & Partial<FrameMsg>) {
 
   beatCounter.textContent = `Beat: ${beat}`;
 
+  // Silhouette overlay
+  if (silhouette) {
+    silhouetteOverlay.src = `data:image/jpeg;base64,${silhouette}`;
+    silhouetteOverlay.classList.remove('hidden');
+  }
+
+  updateScoreText(scores, effect_ms);
   updatePlayerScores(scores, cumulative, effect_ms);
-  updateBorderFlash(scores, effect_ms);
 }
 
-// ── Per-player score display ──────────────────────────────────────────────
+// ── Score text pop ────────────────────────────────────────────────────────
+const LABEL: Record<string, string> = {
+  GREAT: 'GREAT!',
+  OK:    'GOOD!',
+  BAD:   'BAD!',
+};
+
+function updateScoreText(scores: Record<string, string>, effectMs: number | null) {
+  if (effectMs === null || effectMs >= EFFECT_DURATION_MS) return;
+  // Only trigger on the very first message of a new effect (effectMs is small)
+  if (effectMs > 80) return;
+
+  // Best rating across all players
+  const ratings = Object.values(scores);
+  let best = 'BAD';
+  if (ratings.includes('GREAT')) best = 'GREAT';
+  else if (ratings.includes('OK')) best = 'OK';
+
+  // Remove old animation class, force reflow, re-add
+  scoreText.classList.remove('pop', 'GREAT', 'OK', 'BAD');
+  scoreText.textContent = LABEL[best];
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  scoreText.offsetWidth; // reflow trick to restart animation
+  scoreText.classList.add(best, 'pop');
+
+  if (scorePopTimeout) clearTimeout(scorePopTimeout);
+  scorePopTimeout = setTimeout(() => {
+    scoreText.classList.remove('pop');
+  }, 600);
+}
+
+// ── Per-player score cards ────────────────────────────────────────────────
 function updatePlayerScores(
   scores: Record<string, string>,
   cumulative: Record<string, number>,
@@ -145,24 +181,18 @@ function updatePlayerScores(
 ) {
   const now = Date.now();
 
-  // Record new ratings when the effect is fresh
   if (effectMs !== null && effectMs < EFFECT_DURATION_MS) {
     for (const [id, rating] of Object.entries(scores)) {
       playerStates.set(id, { rating, updatedAt: now });
     }
   }
 
-  // Also ensure players with cumulative scores are tracked
   for (const id of Object.keys(cumulative)) {
-    if (!playerStates.has(id)) {
-      playerStates.set(id, { rating: 'idle', updatedAt: 0 });
-    }
+    if (!playerStates.has(id)) playerStates.set(id, { rating: 'idle', updatedAt: 0 });
   }
 
-  // Render / update a card per known player
   for (const [id, state] of playerStates.entries()) {
-    const age = now - state.updatedAt;
-    const isActive = age < EFFECT_DURATION_MS;
+    const isActive   = now - state.updatedAt < EFFECT_DURATION_MS;
     const totalScore = cumulative[id] ?? 0;
 
     let card = document.getElementById(`player-${id}`);
@@ -173,40 +203,18 @@ function updatePlayerScores(
     }
 
     card.className = `player-score ${isActive ? state.rating : 'idle'}`;
-    card.innerHTML = `<div>P${id}</div><div>${isActive ? state.rating : '...'}</div><div style="font-size:0.9rem;opacity:0.8">${totalScore} pts</div>`;
+    card.innerHTML  = `<div>P${id}</div>`
+                    + `<div>${isActive ? LABEL[state.rating] ?? state.rating : '...'}</div>`
+                    + `<div style="font-size:0.9rem;opacity:0.75">${totalScore} pts</div>`;
   }
 
-  // Remove players not seen for 5 s
+  // Remove players gone for > 5 s
   for (const [id, state] of playerStates.entries()) {
     if (state.updatedAt > 0 && now - state.updatedAt > 5000) {
       playerStates.delete(id);
       document.getElementById(`player-${id}`)?.remove();
     }
   }
-}
-
-// ── Border flash ──────────────────────────────────────────────────────────
-const COLOR: Record<string, string> = {
-  GREAT: '#00cc55',
-  OK: '#ddcc00',
-  BAD: '#dd2222',
-};
-
-function updateBorderFlash(scores: Record<string, string>, effectMs: number | null) {
-  if (effectMs === null || effectMs >= EFFECT_DURATION_MS) {
-    borderFlash.style.borderColor = 'transparent';
-    return;
-  }
-
-  // Show the best rating across all active players
-  const ratings = Object.values(scores);
-  let best = 'BAD';
-  if (ratings.includes('GREAT')) best = 'GREAT';
-  else if (ratings.includes('OK')) best = 'OK';
-
-  const fade = 1 - effectMs / EFFECT_DURATION_MS;
-  borderFlash.style.borderColor = COLOR[best] ?? '#fff';
-  borderFlash.style.opacity = String(fade);
 }
 
 // ── Upload ────────────────────────────────────────────────────────────────
@@ -237,11 +245,10 @@ async function uploadSong() {
 }
 
 // ── Wire up buttons ───────────────────────────────────────────────────────
-document.getElementById('btn-refresh')!.onclick     = loadSongs;
-document.getElementById('btn-show-upload')!.onclick = () => uploadForm.classList.toggle('hidden');
-document.getElementById('btn-start')!.onclick       = startGame;
-document.getElementById('btn-stop')!.onclick        = stopGame;
-document.getElementById('btn-upload')!.onclick      = uploadSong;
+document.getElementById('btn-refresh')!.onclick      = loadSongs;
+document.getElementById('btn-show-upload')!.onclick  = () => uploadForm.classList.toggle('hidden');
+document.getElementById('btn-start')!.onclick        = startGame;
+document.getElementById('btn-stop')!.onclick         = stopGame;
+document.getElementById('btn-upload')!.onclick       = uploadSong;
 
-// Initial load
 loadSongs();

--- a/server.py
+++ b/server.py
@@ -18,6 +18,7 @@ import threading
 import json
 from pathlib import Path
 
+import numpy as np
 import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Form, BackgroundTasks
 from fastapi.responses import FileResponse
@@ -38,12 +39,25 @@ app.add_middleware(
 
 SONG_DIR = Path("./song")
 
-# --- Global state ---
+# ---------------------------------------------------------------------------
+# Global state  (webcam is NOT opened here — only inside run_game_loop)
+# ---------------------------------------------------------------------------
 _connected: list[WebSocket] = []
 _game_running = False
 _main_loop: asyncio.AbstractEventLoop | None = None
-_webcam = cv2.VideoCapture(0)
 _pose_comparator = PoseComparator()
+
+# COCO skeleton connections (index pairs into the 17-keypoint array)
+_SKELETON = [
+    (5, 7), (7, 9),    # left arm
+    (6, 8), (8, 10),   # right arm
+    (5, 6),            # shoulders
+    (11, 13), (13, 15),# left leg
+    (12, 14), (14, 16),# right leg
+    (11, 12),          # hips
+    (5, 11), (6, 12),  # torso sides
+    (0, 5), (0, 6),    # neck → shoulders
+]
 
 
 # ---------------------------------------------------------------------------
@@ -87,30 +101,28 @@ def ensure_poses_loaded(song_name: str):
     """Re-extract poses from the saved video if not already in memory."""
     try:
         get_huge_shit(song_name)
-        return  # already loaded
+        return
     except KeyError:
         pass
 
     video_path = SONG_DIR / song_name / f"{song_name}.mp4"
-    meta_path = SONG_DIR / song_name / f"{song_name}.meta"
+    meta_path  = SONG_DIR / song_name / f"{song_name}.meta"
     if not video_path.exists() or not meta_path.exists():
         return
 
     print(f"Loading poses for '{song_name}' from disk...")
-    # Reuse the YOLO model already loaded inside PoseComparator instead of
-    # creating a second instance.
     model = _pose_comparator.foregroundPersons.yolo_pose_model
 
-    bpm = int(meta_path.read_text().strip())
-    sample_ms = int(1000 / (bpm / 60))  # ms per beat
+    bpm       = int(meta_path.read_text().strip())
+    sample_ms = int(1000 / (bpm / 60))
 
-    cap = cv2.VideoCapture(str(video_path))
-    fps = cap.get(cv2.CAP_PROP_FPS)
+    cap         = cv2.VideoCapture(str(video_path))
+    fps         = cap.get(cv2.CAP_PROP_FPS)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     duration_ms = int(frame_count / fps * 1000)
 
     rows: list[list] = [[i, None] for i in range(0, duration_ms, sample_ms)]
-    csv_idx = 0
+    csv_idx      = 0
     total_frames = 0
 
     while cap.isOpened() and csv_idx < len(rows) - 1:
@@ -130,6 +142,47 @@ def ensure_poses_loaded(song_name: str):
     cap.release()
     add_huge_shit(song_name, rows)
     print(f"Loaded {csv_idx} pose keyframes for '{song_name}'")
+
+
+def _draw_silhouette(frame: np.ndarray, people: list) -> str | None:
+    """
+    Draw a glowing cyan skeleton silhouette on a black canvas.
+    Returns base64-encoded JPEG, or None if no people detected.
+    The frontend uses mix-blend-mode:screen so black → transparent.
+    """
+    if not people:
+        return None
+
+    h, w   = frame.shape[:2]
+    out_w, out_h = 320, 240
+    sx, sy = out_w / w, out_h / h
+
+    canvas = np.zeros((out_h, out_w, 3), dtype=np.uint8)
+
+    for (_tid, keypoints) in people:
+        kps = (keypoints * np.array([sx, sy])).astype(int)
+
+        # Draw limb lines
+        for a, b in _SKELETON:
+            if a >= len(kps) or b >= len(kps):
+                continue
+            pa, pb = tuple(kps[a]), tuple(kps[b])
+            if (pa[0] == 0 and pa[1] == 0) or (pb[0] == 0 and pb[1] == 0):
+                continue
+            cv2.line(canvas, pa, pb, (180, 240, 255), 9)
+
+        # Draw joint dots
+        for kp in kps:
+            if kp[0] != 0 or kp[1] != 0:
+                cv2.circle(canvas, tuple(kp), 6, (255, 255, 255), -1)
+
+    # Glow: blur and add back on top
+    if np.any(canvas > 0):
+        glow   = cv2.GaussianBlur(canvas, (23, 23), 0)
+        canvas = cv2.addWeighted(canvas, 1.0, glow, 1.3, 0)
+
+    _, buf = cv2.imencode(".jpg", canvas, [cv2.IMWRITE_JPEG_QUALITY, 75])
+    return base64.b64encode(buf).decode()
 
 
 async def broadcast(message: dict):
@@ -157,20 +210,28 @@ def run_game_loop(song_name: str):
         _game_running = False
         return
 
-    video_path = SONG_DIR / song_name / f"{song_name}.mp4"
-    cap = cv2.VideoCapture(str(video_path))
-    timestamps_and_poses = get_huge_shit(song_name)
-    begin_song_time_ms = int(timestamps_and_poses[0][0])  # ms from start
+    # Open webcam HERE so it's released when the game ends
+    webcam = cv2.VideoCapture(0)
+    if not webcam.isOpened():
+        print("Error: could not open webcam.")
+        _game_running = False
+        return
 
-    video_offset = 0.20  # seconds, for audio-video sync
-    real_start = time.time()
-    prev_beat = 0
+    video_path          = SONG_DIR / song_name / f"{song_name}.mp4"
+    cap                 = cv2.VideoCapture(str(video_path))
+    timestamps_and_poses= get_huge_shit(song_name)
+    begin_song_time_ms  = int(timestamps_and_poses[0][0])
+
+    video_offset = 0.20
+    real_start   = time.time()
+    prev_beat    = 0
 
     shared: dict = {
         "latest_scores": {},
-        "effect_start": None,
-        "face_events": [],
-        "cumulative": {},   # {player_id: int score}
+        "effect_start":  None,
+        "face_events":   [],
+        "cumulative":    {},
+        "silhouette":    None,
     }
     lock = threading.Lock()
 
@@ -178,76 +239,90 @@ def run_game_loop(song_name: str):
         if beat_idx >= len(timestamps_and_poses):
             return
         current_pose = timestamps_and_poses[beat_idx][1]
-        ret, frame = _webcam.read()
+
+        ret, wc_frame = webcam.read()
         if not ret:
             return
-        raw = _pose_comparator.compare_all_players(current_pose, frame)
+
+        # Full analysis: depth filter → YOLO tracking → compare poses
+        people = _pose_comparator.analyze_image(wc_frame)
 
         def to_rating(sim: float) -> str:
-            if sim < 0.45:
-                return "GREAT"
-            if sim < 0.8:
-                return "OK"
+            if sim < 0.45: return "GREAT"
+            if sim < 0.8:  return "OK"
             return "BAD"
 
-        ratings = {str(tid): to_rating(s) for tid, s in raw.items()} if raw else {}
+        ratings = {}
+        if people and current_pose is not None:
+            for track_id, keypoints in people:
+                sim = _pose_comparator.compare_poses(current_pose, keypoints)
+                ratings[str(track_id)] = to_rating(sim)
+
+        silhouette = _draw_silhouette(wc_frame, people)
+
         score_map = {"GREAT": 10, "OK": 5, "BAD": 0}
         with lock:
             shared["latest_scores"] = ratings
-            shared["effect_start"] = time.time()
+            shared["effect_start"]  = time.time()
+            shared["silhouette"]    = silhouette
             shared["face_events"].append((elapsed_s * 1000, ratings))
             for pid, rating in ratings.items():
                 shared["cumulative"][pid] = shared["cumulative"].get(pid, 0) + score_map[rating]
         print(f"Beat {beat_idx}: {ratings}")
 
-    while cap.isOpened() and _game_running:
-        elapsed_s = time.time() - real_start - video_offset
-        elapsed_s = max(0.001, elapsed_s)
-        cap.set(cv2.CAP_PROP_POS_MSEC, elapsed_s * 1000)
-        ret, frame = cap.read()
-        if not ret:
-            break
+    try:
+        while cap.isOpened() and _game_running:
+            elapsed_s = time.time() - real_start - video_offset
+            elapsed_s = max(0.001, elapsed_s)
+            cap.set(cv2.CAP_PROP_POS_MSEC, elapsed_s * 1000)
+            ret, frame = cap.read()
+            if not ret:
+                break
 
-        # Encode frame to JPEG base64 for WebSocket transport
-        _, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 55])
-        frame_b64 = base64.b64encode(buf).decode()
+            _, buf      = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 55])
+            frame_b64   = base64.b64encode(buf).decode()
 
-        beats_per_second = tempo / 60.0
-        current_beat = max(
-            0,
-            math.floor((elapsed_s - begin_song_time_ms / 1000.0) * beats_per_second),
-        )
+            beats_per_second = tempo / 60.0
+            current_beat = max(
+                0,
+                math.floor((elapsed_s - begin_song_time_ms / 1000.0) * beats_per_second),
+            )
 
-        if current_beat > prev_beat:
-            prev_beat = current_beat
-            threading.Thread(
-                target=process_beat,
-                args=(current_beat, elapsed_s),
-                daemon=True,
-            ).start()
+            if current_beat > prev_beat:
+                prev_beat = current_beat
+                threading.Thread(
+                    target=process_beat,
+                    args=(current_beat, elapsed_s),
+                    daemon=True,
+                ).start()
 
-        with lock:
-            scores_snap = dict(shared["latest_scores"])
-            effect_start = shared["effect_start"]
-            cumulative_snap = dict(shared["cumulative"])
+            with lock:
+                scores_snap    = dict(shared["latest_scores"])
+                effect_start   = shared["effect_start"]
+                cumulative_snap= dict(shared["cumulative"])
+                silhouette_b64 = shared["silhouette"]
 
-        effect_ms = (time.time() - effect_start) * 1000 if effect_start else None
+            effect_ms = (time.time() - effect_start) * 1000 if effect_start else None
 
-        msg = {
-            "type": "frame",
-            "frame": frame_b64,
-            "scores": scores_snap,
-            "cumulative": cumulative_snap,
-            "beat": current_beat,
-            "effect_ms": effect_ms,
-        }
+            msg = {
+                "type":       "frame",
+                "frame":      frame_b64,
+                "scores":     scores_snap,
+                "cumulative": cumulative_snap,
+                "beat":       current_beat,
+                "effect_ms":  effect_ms,
+                "silhouette": silhouette_b64,
+            }
 
-        if _main_loop and not _main_loop.is_closed():
-            asyncio.run_coroutine_threadsafe(broadcast(msg), _main_loop)
+            if _main_loop and not _main_loop.is_closed():
+                asyncio.run_coroutine_threadsafe(broadcast(msg), _main_loop)
 
-        time.sleep(1 / 30)  # cap at ~30 fps
+            time.sleep(1 / 30)
+    finally:
+        cap.release()
+        webcam.release()          # <-- webcam shut down here, always
+        print("Webcam released.")
 
-    cap.release()
     set_detection_events(shared["face_events"])
     _game_running = False
     if _main_loop and not _main_loop.is_closed():
@@ -316,10 +391,6 @@ def get_audio(song_name: str):
 
 @app.get("/stats")
 def get_stats():
-    """
-    Returns per-player statistics from the last completed game session.
-    detection_events = [(timestamp_ms, {player_id: rating}), ...]
-    """
     events = get_detection_events()
     if not events:
         return {"players": {}}
@@ -345,13 +416,12 @@ async def ws_endpoint(ws: WebSocket):
     _connected.append(ws)
     try:
         while True:
-            await ws.receive_text()  # keep connection alive
+            await ws.receive_text()
     except WebSocketDisconnect:
         if ws in _connected:
             _connected.remove(ws)
 
 
-# Serve the built TypeScript frontend (after running `npm run build` in frontend/)
 _frontend_dist = Path("frontend/dist")
 if _frontend_dist.exists():
     app.mount("/", StaticFiles(directory=str(_frontend_dist), html=True), name="static")


### PR DESCRIPTION
server.py:
- Webcam is now opened inside run_game_loop and released in a finally block, so it always shuts down when the game ends or errors out
- Removed module-level cv2.VideoCapture(0) that was never released
- process_beat now calls analyze_image directly to reuse detected keypoints for both scoring and silhouette drawing
- _draw_silhouette(): renders a glowing cyan skeleton on a black canvas using COCO skeleton connections + Gaussian blur glow; sent as base64 JPEG per beat alongside the video frame

frontend/index.html + main.ts:
- Replaced border flash with a centred "GREAT!" / "GOOD!" / "BAD!" text pop with a scale + fade-out CSS animation
- Added #silhouette-overlay <img> in the bottom-right corner of the video; mix-blend-mode:screen makes the black background invisible so only the glowing skeleton shows through
- Player score cards now show the friendly label ("GREAT!" etc.) and cumulative point total